### PR TITLE
Feat: 회원 관련 API 구현

### DIFF
--- a/accounts/serializers.py
+++ b/accounts/serializers.py
@@ -1,0 +1,19 @@
+from rest_framework import serializers
+
+from .models import PillingUser
+
+class PillingUserResponseSerializer(serializers.ModelSerializer):
+    pilling_user_id = serializers.IntegerField(source='id', read_only=True)
+
+    class Meta:
+        model = PillingUser
+        fields = ['pilling_user_id', 'nickname', 'kakao_sub']
+        extra_kwargs = {
+            field: {'read_only': True} for field in fields
+        }
+
+class KakaoLoginRequestSerializer(serializers.Serializer):
+    access_code = serializers.CharField()
+    
+class UserPatchSerializer(serializers.Serializer):
+    nickname = serializers.CharField()

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -1,3 +1,125 @@
-from django.shortcuts import render
+import os
+import base64
+import json
 
-# Create your views here.
+import requests
+
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.permissions import IsAuthenticated, AllowAny
+from rest_framework.response import Response
+
+from rest_framework_simplejwt.tokens import RefreshToken
+
+from .models import PillingUser
+from .serializers import KakaoLoginRequestSerializer, UserPatchSerializer, PillingUserResponseSerializer
+
+class KakaoAccessTokenException(Exception):
+    pass
+
+class KakaoOIDCException(Exception):
+    pass
+
+class KakaoDataException(Exception):
+    pass
+
+def exchange_kakao_access_token(access_code):
+    response = requests.post(
+        'https://kauth.kakao.com/oauth/token',
+        headers={
+            'Content-type': 'application/x-www-form-urlencoded;charset=utf-8',
+        },
+        data={
+            'grant_type': 'authorization_code',
+            'client_id': os.environ.get('KAKAO_REST_API_KEY'),
+            'redirect_uri': os.environ.get('KAKAO_REDIRECT_URI'),
+            'code': access_code,
+        },
+    )
+    if response.status_code >= 300:
+        raise KakaoAccessTokenException()
+    return response.json()
+
+def verify_kakao_oidc(kakao_data):
+    if kakao_data.get('id_token', None) is None:
+        raise KakaoDataException()
+    # todo: implement OIDC verify code here...
+
+def extract_kakao_nickname(kakao_data):
+    id_token = kakao_data.get('id_token', None)
+    if id_token is None:
+        raise KakaoDataException()
+    try:
+        payload_encoded = id_token.split('.')[1]
+        payload_decoded = base64.urlsafe_b64decode(payload_encoded + '=' * (4 - len(payload_encoded) % 4))
+        payload = json.loads(payload_decoded)
+    except:
+        raise KakaoDataException()
+    return payload['nickname']
+
+def extract_kakao_sub(kakao_data):
+    id_token = kakao_data.get('id_token', None)
+    if id_token is None:
+        raise KakaoDataException()
+    try:
+        payload_encoded = id_token.split('.')[1]
+        payload_decoded = base64.urlsafe_b64decode(payload_encoded + '=' * (4 - len(payload_encoded) % 4))
+        payload = json.loads(payload_decoded)
+    except:
+        raise KakaoDataException()
+    return payload['sub']
+
+@api_view(['POST'])
+@permission_classes([AllowAny])
+def kakao_login(request):
+    serializer = KakaoLoginRequestSerializer(data=request.data)
+    serializer.is_valid(raise_exception=True)
+    data = serializer.validated_data
+
+    try:
+        kakao_data = exchange_kakao_access_token(data['access_code'])
+        verify_kakao_oidc(kakao_data)
+        nickname = extract_kakao_nickname(kakao_data)
+        sub = extract_kakao_sub(kakao_data)
+    except KakaoAccessTokenException:
+        return Response({'detail': 'Access token 교환에 실패했습니다.'}, status=401)
+    except KakaoDataException:
+        return Response({'detail': 'OIDC token 정보를 확인할 수 없습니다.'}, status=401)
+    except KakaoOIDCException:
+        return Response({'detail': 'OIDC 인증에 실패했습니다.'}, status=401)
+
+    try:
+        user = PillingUser.objects.get(kakao_sub=sub)
+    except PillingUser.DoesNotExist:
+        user = PillingUser.objects.create_user(nickname=nickname, kakao_sub=sub)
+
+    refresh = RefreshToken.for_user(user)
+    return Response({
+        'access_token': str(refresh.access_token),
+        'refresh_token': str(refresh)
+    })
+    
+@api_view(['GET', 'PATCH'])
+@permission_classes([IsAuthenticated])
+def user_detail(request):
+    if request.method == 'GET':
+        users = PillingUser.objects.all()
+        serializer = PillingUserResponseSerializer(users, many=True)
+        return Response(serializer.data)
+    elif request.method == 'PATCH':
+        user = PillingUser.objects.get(nickname=request.user.nickname)
+        
+        patchSerializer = UserPatchSerializer(data=request.data)
+        patchSerializer.is_valid(raise_exception=True)
+        data = patchSerializer.validated_data
+        
+        user.nickname = data['nickname']
+        user.save()
+        
+        serializer = PillingUserResponseSerializer(user)
+        return Response(serializer.data)
+    
+@api_view(['GET'])
+@permission_classes([IsAuthenticated])
+def user_my_detail(request):
+    serializer = PillingUserResponseSerializer(request.user)
+    return Response(serializer.data)

--- a/config/settings.py
+++ b/config/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/5.0/ref/settings/
 import os
 from pathlib import Path
 from dotenv import load_dotenv
+from datetime import timedelta
 
 load_dotenv()
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -112,6 +113,9 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
+SIMPLE_JWT = {
+    'ACCESS_TOKEN_LIFETIME': timedelta(minutes=60*24),
+}
 
 # Internationalization
 # https://docs.djangoproject.com/en/5.0/topics/i18n/

--- a/config/urls.py
+++ b/config/urls.py
@@ -17,6 +17,13 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path
 
+from accounts.views import kakao_login, user_my_detail, user_detail
+# from tags.views import access_tag
+
 urlpatterns = [
     path('admin/', admin.site.urls),
+    
+    path('auth/kakao/login', kakao_login),
+    path('users/me', user_my_detail),
+    path('users', user_detail)
 ]

--- a/tags/models.py
+++ b/tags/models.py
@@ -1,7 +1,4 @@
 from django.db import models
 
-from medicines.models import Medicine
-
 class Tag(models.Model):
     content = models.CharField(max_length=10)
-


### PR DESCRIPTION
애거돈 당시에 사용한 API와 대동소이합니다.


## accounts/serializers.py
API 명세서에 맞추기 위해, id를 pilling_user_id라는 이름으로 반환하도록 했습니다.