### PR TITLE
스케줄, 스크랩 기능 정상화

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -26,7 +26,7 @@ from pharms.views import pharm_info
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('scraps/', include('scraps.urls')),
+    path('scraps', include('scraps.urls')),
     path('auth/kakao/login', kakao_login),
     path('users/me', user_my_detail),
     path('users', user_detail),

--- a/scraps/urls.py
+++ b/scraps/urls.py
@@ -2,9 +2,9 @@ from django.urls import path
 from .views import ScrapUpdateView,ScrapCreateView,ScrapDestroyView,ScrapListView,ScrapRetreiveView
 
 urlpatterns = [
-    path("new/", ScrapCreateView.as_view(),name="scrap_new"),
-    path("<int:pk>/edit", ScrapUpdateView.as_view(), name="scrap_edit"),
-    path("<int:pk>/delete", ScrapDestroyView.as_view(), name="scrap_delete"),
+    path("/new", ScrapCreateView.as_view(),name="scrap_new"),
+    path("/<int:pk>/edit", ScrapUpdateView.as_view(), name="scrap_edit"),
+    path("/<int:pk>/delete", ScrapDestroyView.as_view(), name="scrap_delete"),
     path("", ScrapListView.as_view(), name="scraps_list"),
-    path("<int:pk>/detail", ScrapRetreiveView.as_view(), name="scrap_detail"),
+    path("/<int:pk>/detail", ScrapRetreiveView.as_view(), name="scrap_detail"),
 ]


### PR DESCRIPTION
필링 사용 흐름상 스케줄 등록을 보자.
1. 프론트에서 간단검색을 해서 원하는 약의 이름, 효능, 사진을 얻는다.
2. 얻은 이름, 효능, 사진으로 스케줄 등록 요청을 백엔드에 보낸다.
3. 디비에 없던 약 이름이라면 먼저 새로 약을 생성하는데, 저 세 가지 정보만 가지고 약 객체가 생성된다. 용법 주의사항 이런거 없음. 그다음에 그 생성된 약 객체로 스케줄 생성한다.
4. 디비에 있던 약 이름이라면 그 약 객체로 스케줄 생성한다.

이제 필링 사용 흐름상 스크랩 등록을 보자.
1. 사용자는 메인화면에서 검색기능을 들어가고, 상세검색을 해서 원하는 약의 모든 정보를 얻는다. 용법 주의사항 등등 다 포함
2. 그 모든 정보를 바디에 넣어 스크랩 등록 요청을 백엔드에 보낸다.
3. 디비에 없던 약 이름이라면 새로 약 생성하고 그 약 객체로 스크랩 생성한다.
4. 디비에 있던 약 이름이라면, 먼저 그 약의 용법 주의사항 등까지 디비에 있는지 본다. 있다면, 그 약 객체로 스크랩 생성한다.
5. 디비에 있던 약 이름인데, 용법 주의사항 등의 정보는 없었다면, 추가적인 정보를 디비에 저장한 뒤에 그 약 객체로 스크랩 생성한다.

위 내용대로 구현했습니다.